### PR TITLE
Added latest info to metadata and created download methods

### DIFF
--- a/Sources/Nuget.Server.AzureStorage/AzurePackageService.cs
+++ b/Sources/Nuget.Server.AzureStorage/AzurePackageService.cs
@@ -1,0 +1,82 @@
+﻿using NuGet;
+using NuGet.Server;
+using NuGet.Server.DataServices;
+using NuGet.Server.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Routing;
+using System.Web;
+using System.Net;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Nuget.Server.AzureStorage.Domain.Services;
+using System.IO;
+
+namespace Nuget.Server.AzureStorage
+{
+    public class AzurePackageService : PackageService, IPackageService
+    {
+        private readonly AzureServerPackageRepository _azureRepository;
+
+        public AzurePackageService(AzureServerPackageRepository repository,
+                              IPackageAuthenticationService authenticationService)
+            : base(repository, authenticationService)
+        {
+            _azureRepository = repository;
+        }
+
+        public void DownloadPackage(HttpContextBase context)
+        {
+            RouteData routeData = GetRouteData(context);
+            // Get the package file name from the route
+            string packageId = routeData.GetRequiredString("packageId");
+            var version = new SemanticVersion(routeData.GetRequiredString("version"));
+
+            string filename = packageId + "." + version.ToString() + ".nupkg";
+
+            IPackage requestedPackage = _azureRepository.FindPackage(packageId, version);
+
+            if (requestedPackage != null)
+            {
+                CloudBlockBlob blob = _azureRepository.GetBlob(requestedPackage);
+
+                MemoryStream ms = new MemoryStream();
+                blob.DownloadToStream(ms);
+
+                context.Response.Clear();
+                context.Response.AddHeader("content-disposition", String.Format("attachment; filename={0}", filename));
+                context.Response.ContentType = "application/octet-stream";
+                context.Response.BinaryWrite(ms.ToArray());
+                context.Response.End();
+                
+            }
+            else
+            {
+                // Package not found
+                WritePackageNotFound(context, packageId, version);
+            }
+        }
+
+        private static void WritePackageNotFound(HttpContextBase context, string packageId, SemanticVersion version)
+        {
+            WriteStatus(context, HttpStatusCode.NotFound, String.Format("'Package {0} {1}' Not found.", packageId, version));
+        }
+
+        private static void WriteStatus(HttpContextBase context, HttpStatusCode statusCode, string body = null)
+        {
+            context.Response.StatusCode = (int)statusCode;
+            if (!String.IsNullOrEmpty(body))
+            {
+                context.Response.StatusDescription = body;
+            }
+        }
+
+        private RouteData GetRouteData(HttpContextBase context)
+        {
+            return RouteTable.Routes.GetRouteData(context);
+        }
+    }
+}

--- a/Sources/Nuget.Server.AzureStorage/AzureServerPackageRepository .cs
+++ b/Sources/Nuget.Server.AzureStorage/AzureServerPackageRepository .cs
@@ -59,8 +59,19 @@ namespace Nuget.Server.AzureStorage
         /// <returns></returns>
         public Package GetMetadataPackage(IPackage package)
         {
+            var derived = new DerivedPackageData() {
+                //Created = ?
+                //FullPath = ?
+                IsAbsoluteLatestVersion = package.IsAbsoluteLatestVersion,
+                IsLatestVersion = package.IsLatestVersion
+                //LastUpdated = ?
+                //PackageHash = package.GetHash(),
+                //PackageSize = ??
+                //Path = ??
+                //SupportedFrameworks = package.GetSupportedFrameworks(),
+            };
             //var pkg = new Package(package, new DerivedPackageData());
-            return new Package(package, new DerivedPackageData());
+            return new Package(package, derived);
         }
 
         /// <summary>
@@ -261,6 +272,41 @@ namespace Nuget.Server.AzureStorage
             var latest = container.Metadata[Constants.LastUploadedVersion];
 
             return container.GetBlockBlobReference(latest);
+        }
+
+        /// <summary>
+        /// Gets the package blob.
+        /// </summary>
+        /// <param name="package">The package.</param>
+        public CloudBlockBlob GetBlob(IPackage package)
+        {
+            var name = _packageLocator.GetContainerName(package);
+            var container = _blobClient.GetContainerReference(name);
+
+            if (container.Exists())
+            {
+                var blobName = _packageLocator.GetItemName(package);
+                var blob = container.GetBlockBlobReference(blobName);
+                return blob;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the package blob.
+        /// </summary>
+        /// <param name="packageId">The package identifier.</param>
+        /// <param name="version">The version.</param>
+        public CloudBlockBlob GetBlob(string packageId, SemanticVersion version)
+        {
+            return GetBlob(new AzurePackage
+            {
+                Id = packageId,
+                Version = version,
+            });
         }
     }
 }

--- a/Sources/Nuget.Server.AzureStorage/Bootstraper.cs
+++ b/Sources/Nuget.Server.AzureStorage/Bootstraper.cs
@@ -4,6 +4,7 @@
     using Nuget.Server.AzureStorage.Domain.Services;
     using Nuget.Server.AzureStorage.Doman.Entities;
     using NuGet;
+    using NuGet.Server;
     using NuGet.Server.Infrastructure;
 
     public static class Bootstraper
@@ -11,6 +12,7 @@
         public static void SetUp()
         {
             NinjectBootstrapper.Kernel.Rebind<IServerPackageRepository>().To<AzureServerPackageRepository>();
+            NinjectBootstrapper.Kernel.Rebind<IPackageService>().To<AzurePackageService>();
             NinjectBootstrapper.Kernel.Bind<IPackageLocator>().To<AzurePackageLocator>();
             NinjectBootstrapper.Kernel.Bind<IAzurePackageSerializer>().To<AzurePackageSerializer>();
 

--- a/Sources/Nuget.Server.AzureStorage/Domain.Services/AzurePackageLocator.cs
+++ b/Sources/Nuget.Server.AzureStorage/Domain.Services/AzurePackageLocator.cs
@@ -16,7 +16,8 @@
 
         private string GetAzureFriendlyString(string packageId)
         {
-            return packageId.ToLower().Replace(".", "-").Replace("_","-");
+            //return packageId.ToLower().Replace(".", "-").Replace("_","-");
+            return packageId.ToLower().Replace("_", "-");
         }
     }
 }

--- a/Sources/Nuget.Server.AzureStorage/Nuget.Server.AzureStorage.csproj
+++ b/Sources/Nuget.Server.AzureStorage/Nuget.Server.AzureStorage.csproj
@@ -112,6 +112,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AzurePackageService.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="AzureServerPackageRepository .cs" />
     <Compile Include="Bootstraper.cs" />


### PR DESCRIPTION
To resolve issue where packages did not show when viewing the feed - added to metadata:
IsAbsoluteLatestVersion
IsLatestVersion

Also added methods to download a package from Azure storage, as this had not been implemented.

Also changed the Azure friendly name method as the dashes were not being resolved.
